### PR TITLE
Remove LRU chat eviction to keep demo simple

### DIFF
--- a/bot/agents.py
+++ b/bot/agents.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 import logging
 import os
 from typing import Any
@@ -22,7 +21,6 @@ DEFAULT_INSTRUCTIONS = (
 )
 
 MAX_TURNS = 25
-MAX_CHATS = 200
 MCP_SESSION_TIMEOUT_SECONDS = 30.0
 
 
@@ -59,30 +57,19 @@ class OpenAIAgent:
             mcp_servers=(mcp_servers if mcp_servers is not None else []),
         )
         self.name = name
-        self._conversations: collections.OrderedDict[int, list[TResponseInputItem]] = collections.OrderedDict()
+        self._conversations: dict[int, list[TResponseInputItem]] = {}
         self._locks: dict[int, asyncio.Lock] = {}
-
-    def _evict_oldest(self) -> None:
-        """Remove the least-recently-used chat when over MAX_CHATS."""
-        while len(self._conversations) > MAX_CHATS:
-            evicted_id, _ = self._conversations.popitem(last=False)
-            self._locks.pop(evicted_id, None)
 
     def get_messages(self, chat_id: int) -> list[TResponseInputItem]:
         return self._conversations.get(chat_id, [])
 
     def set_messages(self, chat_id: int, messages: list[TResponseInputItem]) -> None:
-        # Move to end on update so recently-active chats survive eviction
         self._conversations[chat_id] = messages
-        self._conversations.move_to_end(chat_id)
-        self._evict_oldest()
 
     def append_user_message(self, chat_id: int, message: str) -> None:
         if chat_id not in self._conversations:
             self._conversations[chat_id] = []
         self._conversations[chat_id].append({"role": "user", "content": message})
-        self._conversations.move_to_end(chat_id)
-        self._evict_oldest()
 
     def truncate_history(self, chat_id: int) -> None:
         """Keep only the last MAX_TURNS turns of conversation history.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import create_autospec
 
 import pytest
 from agents.models.interface import Model
 
 from bot.agents import DEFAULT_INSTRUCTIONS
-from bot.agents import MAX_CHATS
 from bot.agents import MAX_TURNS
 from bot.agents import OpenAIAgent
 
@@ -154,74 +152,3 @@ class TestHistoryTruncation:
         msgs = agent.get_messages(chat_id=100)
         user_msgs = [m for m in msgs if m["role"] == "user"]
         assert len(user_msgs) == 3
-
-
-class TestChatEviction:
-    def test_default_max_chats(self):
-        assert MAX_CHATS == 200
-
-    def test_evicts_oldest_chat_when_limit_exceeded(self, monkeypatch):
-        monkeypatch.setattr("bot.agents.MAX_CHATS", 3)
-        agent = OpenAIAgent(name="test")
-
-        agent.set_messages(100, [{"role": "user", "content": "a"}])
-        agent.set_messages(200, [{"role": "user", "content": "b"}])
-        agent.set_messages(300, [{"role": "user", "content": "c"}])
-        # At limit — all present
-        assert len(agent._conversations) == 3
-
-        # Adding a 4th should evict the oldest (100)
-        agent.set_messages(400, [{"role": "user", "content": "d"}])
-        assert 100 not in agent._conversations
-        assert len(agent._conversations) == 3
-        assert set(agent._conversations.keys()) == {200, 300, 400}
-
-    def test_updating_existing_chat_does_not_evict(self, monkeypatch):
-        monkeypatch.setattr("bot.agents.MAX_CHATS", 2)
-        agent = OpenAIAgent(name="test")
-
-        agent.set_messages(100, [{"role": "user", "content": "a"}])
-        agent.set_messages(200, [{"role": "user", "content": "b"}])
-        # Updating chat 100 should not trigger eviction
-        agent.set_messages(100, [{"role": "user", "content": "updated"}])
-        assert len(agent._conversations) == 2
-        assert agent.get_messages(100)[0]["content"] == "updated"
-
-    def test_append_to_new_chat_triggers_eviction(self, monkeypatch):
-        monkeypatch.setattr("bot.agents.MAX_CHATS", 2)
-        agent = OpenAIAgent(name="test")
-
-        agent.set_messages(100, [{"role": "user", "content": "a"}])
-        agent.set_messages(200, [{"role": "user", "content": "b"}])
-        agent.append_user_message(300, "c")
-
-        assert 100 not in agent._conversations
-        assert len(agent._conversations) == 2
-
-    def test_accessing_chat_refreshes_its_position(self, monkeypatch):
-        monkeypatch.setattr("bot.agents.MAX_CHATS", 3)
-        agent = OpenAIAgent(name="test")
-
-        agent.set_messages(100, [{"role": "user", "content": "a"}])
-        agent.set_messages(200, [{"role": "user", "content": "b"}])
-        agent.set_messages(300, [{"role": "user", "content": "c"}])
-
-        # Access chat 100 to refresh it (move to end)
-        agent.set_messages(100, [{"role": "user", "content": "refreshed"}])
-
-        # Now 200 is oldest — adding 400 should evict 200, not 100
-        agent.set_messages(400, [{"role": "user", "content": "d"}])
-        assert 200 not in agent._conversations
-        assert 100 in agent._conversations
-
-    def test_eviction_also_cleans_up_lock(self, monkeypatch):
-        monkeypatch.setattr("bot.agents.MAX_CHATS", 2)
-        agent = OpenAIAgent(name="test")
-
-        agent._locks[100] = asyncio.Lock()
-        agent.set_messages(100, [{"role": "user", "content": "a"}])
-        agent._locks[200] = asyncio.Lock()
-        agent.set_messages(200, [{"role": "user", "content": "b"}])
-
-        agent.set_messages(300, [{"role": "user", "content": "c"}])
-        assert 100 not in agent._locks


### PR DESCRIPTION
## Summary

- Revert `OrderedDict` + `MAX_CHATS` eviction back to plain `dict`
- Remove `TestChatEviction` test class (6 tests)
- Demo bot usage patterns don't warrant the added complexity

## Test plan

- [x] 99 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)