### PR TITLE
feat: add WebSearchTool for standard OpenAI Responses API

### DIFF
--- a/bot/agents.py
+++ b/bot/agents.py
@@ -8,6 +8,7 @@ from typing import Any
 from agents import Agent
 from agents import Runner
 from agents import TResponseInputItem
+from agents import WebSearchTool
 from agents.mcp import MCPServerStdio
 from agents.mcp import MCPServerStreamableHttp
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -26,6 +27,11 @@ MAX_TURNS = 10
 MCP_SESSION_TIMEOUT_SECONDS = 30.0
 
 
+def _is_azure() -> bool:
+    """Check whether Azure OpenAI credentials are configured."""
+    return bool(os.getenv("AZURE_OPENAI_API_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"))
+
+
 def _get_model() -> OpenAIResponsesModel | OpenAIChatCompletionsModel:
     """Create an OpenAI model from environment variables.
 
@@ -37,7 +43,7 @@ def _get_model() -> OpenAIResponsesModel | OpenAIChatCompletionsModel:
     api_type = os.getenv("OPENAI_API_TYPE", "responses")
 
     client: AsyncOpenAI
-    if os.getenv("AZURE_OPENAI_API_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"):
+    if _is_azure():
         client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
@@ -60,11 +66,16 @@ class OpenAIAgent:
         mcp_servers: list | None = None,
         instructions: str = DEFAULT_INSTRUCTIONS,
     ) -> None:
+        model = _get_model()
+        tools: list = []
+        if isinstance(model, OpenAIResponsesModel) and not _is_azure():
+            tools.append(WebSearchTool())
         self.agent = Agent(
             name=name,
             instructions=instructions,
-            model=_get_model(),
+            model=model,
             mcp_servers=(mcp_servers if mcp_servers is not None else []),
+            tools=tools,
         )
         self.name = name
         self._conversations: dict[int, list[TResponseInputItem]] = {}

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,6 +5,7 @@ from unittest.mock import create_autospec
 from unittest.mock import patch
 
 import pytest
+from agents import WebSearchTool
 from agents.models.interface import Model
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_responses import OpenAIResponsesModel
@@ -217,3 +218,34 @@ class TestHistoryTruncation:
         msgs = agent.get_messages(chat_id=100)
         user_msgs = [m for m in msgs if m["role"] == "user"]
         assert len(user_msgs) == 3
+
+
+class TestWebSearchTool:
+    def test_web_search_tool_included_with_standard_openai_responses(self, monkeypatch):
+        """WebSearchTool should be added when using Responses API with standard OpenAI."""
+        mock_model = create_autospec(OpenAIResponsesModel)
+        monkeypatch.setattr("bot.agents._get_model", lambda: mock_model)
+        monkeypatch.setattr("bot.agents._is_azure", lambda: False)
+
+        agent = OpenAIAgent(name="test")
+        web_tools = [t for t in agent.agent.tools if isinstance(t, WebSearchTool)]
+        assert len(web_tools) == 1
+
+    def test_web_search_tool_excluded_with_chat_completions(self, monkeypatch):
+        """WebSearchTool should NOT be added when using Chat Completions API."""
+        mock_model = create_autospec(OpenAIChatCompletionsModel)
+        monkeypatch.setattr("bot.agents._get_model", lambda: mock_model)
+
+        agent = OpenAIAgent(name="test")
+        web_tools = [t for t in agent.agent.tools if isinstance(t, WebSearchTool)]
+        assert len(web_tools) == 0
+
+    def test_web_search_tool_excluded_with_azure(self, monkeypatch):
+        """WebSearchTool should NOT be added when using Azure, even with Responses API."""
+        mock_model = create_autospec(OpenAIResponsesModel)
+        monkeypatch.setattr("bot.agents._get_model", lambda: mock_model)
+        monkeypatch.setattr("bot.agents._is_azure", lambda: True)
+
+        agent = OpenAIAgent(name="test")
+        web_tools = [t for t in agent.agent.tools if isinstance(t, WebSearchTool)]
+        assert len(web_tools) == 0


### PR DESCRIPTION
Extract _is_azure() helper to share Azure detection between _get_model() and tool selection, avoiding access to SDK private attributes.