### PR TITLE
fix: use standard MCP config key "url" instead of "httpUrl"

### DIFF
--- a/bot/agents.py
+++ b/bot/agents.py
@@ -95,12 +95,12 @@ class OpenAIAgent:
     def from_dict(cls, name: str, config: dict[str, Any]) -> OpenAIAgent:
         mcp_servers: list[MCPServerStreamableHttp | MCPServerStdio] = []
         for mcp_srv in config.get("mcpServers", {}).values():
-            if "httpUrl" in mcp_srv:
+            if "url" in mcp_srv:
                 mcp_servers.append(
                     MCPServerStreamableHttp(
                         client_session_timeout_seconds=MCP_SESSION_TIMEOUT_SECONDS,
                         params={
-                            "url": mcp_srv["httpUrl"],
+                            "url": mcp_srv["url"],
                             "headers": mcp_srv.get("headers", {}),
                         },
                     )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,6 +5,8 @@ from unittest.mock import create_autospec
 from unittest.mock import patch
 
 import pytest
+from agents.mcp import MCPServerStdio
+from agents.mcp import MCPServerStreamableHttp
 from agents.models.interface import Model
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_responses import OpenAIResponsesModel
@@ -112,6 +114,57 @@ class TestInstructions:
         }
         agent = OpenAIAgent.from_dict("test", config)
         assert agent.agent.instructions == DEFAULT_INSTRUCTIONS
+
+
+class TestFromDictMcpServers:
+    def test_url_creates_streamable_http_server(self):
+        config = {
+            "mcpServers": {
+                "my-server": {
+                    "url": "http://localhost:8000/mcp",
+                }
+            },
+        }
+        agent = OpenAIAgent.from_dict("test", config)
+        assert len(agent.agent.mcp_servers) == 1
+        assert isinstance(agent.agent.mcp_servers[0], MCPServerStreamableHttp)
+
+    def test_url_passes_headers(self):
+        config = {
+            "mcpServers": {
+                "my-server": {
+                    "url": "http://localhost:8000/mcp",
+                    "headers": {"Authorization": "Bearer token"},
+                }
+            },
+        }
+        agent = OpenAIAgent.from_dict("test", config)
+        server = agent.agent.mcp_servers[0]
+        assert isinstance(server, MCPServerStreamableHttp)
+
+    def test_command_creates_stdio_server(self):
+        config = {
+            "mcpServers": {
+                "my-server": {
+                    "command": "npx",
+                    "args": ["-y", "some-mcp-server"],
+                }
+            },
+        }
+        agent = OpenAIAgent.from_dict("test", config)
+        assert len(agent.agent.mcp_servers) == 1
+        assert isinstance(agent.agent.mcp_servers[0], MCPServerStdio)
+
+    def test_mixed_servers(self):
+        config = {
+            "mcpServers": {
+                "remote": {"url": "http://localhost:8000/mcp"},
+                "local": {"command": "npx", "args": ["-y", "server"]},
+            },
+        }
+        agent = OpenAIAgent.from_dict("test", config)
+        types = {type(s) for s in agent.agent.mcp_servers}
+        assert types == {MCPServerStreamableHttp, MCPServerStdio}
 
 
 class TestHistoryTruncation:


### PR DESCRIPTION
## Summary
- Replace non-standard `httpUrl` config key with `url` to align with MCP specification and Claude Desktop
- Add tests for MCP server config parsing in `from_dict`

## Test plan
- [x] All 107 existing tests pass
- [x] New tests cover `url` → StreamableHttp, `command` → Stdio, mixed configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)